### PR TITLE
fix: Handle error when there is no valueSpan in BondAttribute

### DIFF
--- a/packages/eslint-plugin-angular-template-spacing/src/rules/pipe.rule.spec.ts
+++ b/packages/eslint-plugin-angular-template-spacing/src/rules/pipe.rule.spec.ts
@@ -335,6 +335,16 @@ describe('Pipe Rule', () => {
                 expect(spy).toHaveBeenCalledTimes(0);
             });
 
+            it('should not create a report for attribute without value', () => {
+                const boundAttribute = {
+                    value: { source: '<div [attr]></div>' } as BoundAttribute['value'],
+                } as BoundAttribute & TSESTree.BaseNode;
+                const spy = jest.spyOn(context, 'report');
+                listener.BoundAttribute(boundAttribute);
+
+                expect(spy).toHaveBeenCalledTimes(0);
+            });
+
             it.each([
                 { html: '<div [attr]="something| pipe"></div>', loc: mockLocation([0, 22], [0, 22]) },
                 { html: '<div [attr]="something |pipe"></div>', loc: mockLocation([0, 24], [0, 24]) },

--- a/packages/eslint-plugin-angular-template-spacing/src/rules/pipe.rule.ts
+++ b/packages/eslint-plugin-angular-template-spacing/src/rules/pipe.rule.ts
@@ -80,6 +80,10 @@ export const ruleModule: ModuleType = {
                 }
             },
             BoundAttribute(attribute: BoundAttribute): void {
+                if (!attribute.valueSpan) {
+                    return;
+                }
+
                 const interpolationNode: InterpolationNode = {
                     value: attribute.value.source ?? '',
                     offset: attribute.valueSpan.start.offset,


### PR DESCRIPTION
Hello 👋 
I prepared a fix for issue which occurs, when we have `<div [attr]></div>` in the Angular template. I know, it should either be without brackets `<div attr></div>` or have some value defined, however I think it's worth to patch it and prevent linter from crashing on it.